### PR TITLE
[fix] 액세스 토큰 재발급 400, 401 에러 해결

### DIFF
--- a/src/hooks/useAccessToken.ts
+++ b/src/hooks/useAccessToken.ts
@@ -1,15 +1,7 @@
-import { useEffect } from 'react';
-
 import { useLocalStorage } from 'usehooks-ts';
-
-import { apiService } from '../services/ApiService';
 
 export default function useAccessToken() {
   const [accessToken, setAccessToken] = useLocalStorage('accessToken', '');
-
-  useEffect(() => {
-    apiService.setAccessToken(accessToken);
-  }, [accessToken]);
 
   return { accessToken, setAccessToken };
 }


### PR DESCRIPTION
- 401 에러 대응 : 액세스 토큰 재발급 시 요청 헤더에 Authorization 포함되는 이슈 발견 -> 요청에 Authorization 추가하는 로직 변경
- 400 에러 대응 : 액세스 토큰 재발급 시 config에 { withCredentials : true } 속성이 추가되지 않고 Parameter로 전달되는 이슈 발견 -> Axios request interceptors에서 { withCredentials : true } 추가하는 방식으로 변경