### PR TITLE
[fix] 로그인 시 회원 정보 스토어에 유저 타입 수동으로 저장

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,11 +5,14 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import LoginForm from '../components/login/LoginForm';
 
 import useLoginFormStore from '../hooks/useLoginFormStore';
+import useLoginUserStore from '../hooks/useLoginUserStore';
 
 function LoginPage() {
   const navigate = useNavigate();
 
   const [{ accessToken }, loginFormStore] = useLoginFormStore();
+
+  const [, loginUserStore] = useLoginUserStore();
 
   const [params] = useSearchParams();
 
@@ -30,6 +33,8 @@ function LoginPage() {
       loginFormStore.reset();
 
       localStorage.setItem('userType', userType);
+
+      loginUserStore.setUserType(userType);
 
       navigate('/chatrooms');
     }

--- a/src/stores/LoginUserStore.ts
+++ b/src/stores/LoginUserStore.ts
@@ -9,7 +9,7 @@ import { nullProfile, Profile } from '../types';
 @singleton()
 @Store()
 export default class LoginUserStore {
-  userType = localStorage.getItem('userType') || '';
+  userType = '';
 
   profile : Profile = nullProfile;
 
@@ -26,6 +26,11 @@ export default class LoginUserStore {
   setLoginUser(profile : Profile) {
     this.profile = profile;
     this.error = false;
+  }
+
+  @Action()
+  setUserType(userType: string) {
+    this.userType = userType;
   }
 
   @Action()


### PR DESCRIPTION
- 로그아웃 이후 다른 유저 타입으로 로그인하면 회원 정보 스토어에 유저 타입이 정상적으로 저장되지 않는 현상 발견, 로그인 시 수동으로 저장하여 해결