### PR TITLE
[fix] 회원 정보 스토어 userType 초기값 변경 및 local storage key 상수 변수로 변경

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import LoginForm from '../components/login/LoginForm';
 
+import { LOCAL_STORAGE_KEYS } from '../constants/localStorage';
 import { STATIC_ROUTES } from '../constants/routes';
 
 import useLoginFormStore from '../hooks/useLoginFormStore';
@@ -34,7 +35,7 @@ function LoginPage() {
     if (accessToken) {
       loginFormStore.reset();
 
-      localStorage.setItem('userType', userType);
+      localStorage.setItem(LOCAL_STORAGE_KEYS.USER_TYPE, userType);
 
       loginUserStore.setUserType(userType);
 

--- a/src/stores/LoginUserStore.ts
+++ b/src/stores/LoginUserStore.ts
@@ -2,6 +2,8 @@ import { singleton } from 'tsyringe';
 
 import { Action, Store } from 'usestore-ts';
 
+import { LOCAL_STORAGE_KEYS } from '../constants/localStorage';
+
 import { apiService } from '../services/ApiService';
 
 import { nullProfile, Profile } from '../types';
@@ -9,7 +11,7 @@ import { nullProfile, Profile } from '../types';
 @singleton()
 @Store()
 export default class LoginUserStore {
-  userType = '';
+  userType = localStorage.getItem(LOCAL_STORAGE_KEYS.USER_TYPE) || '';
 
   profile : Profile = nullProfile;
 


### PR DESCRIPTION
- 회원 정보 스토어 userType의 초기값을 빈 문자열 -> 로컬 스토리지의 userType으로 변경
- 로컬 스토리지 userType key 문자열 대신 상수 변수 사용