### PR TITLE
[feat] 소켓 구독, 연결 해제 시 헤더를 통해 서버로 토큰 및 채팅방 번호 전달

### DIFF
--- a/src/hooks/useSockJS.ts
+++ b/src/hooks/useSockJS.ts
@@ -5,10 +5,12 @@ import SockJS from 'sockjs-client';
 
 import { CompatClient, Stomp } from '@stomp/stompjs';
 
+import useAccessToken from './useAccessToken';
 import useChatRoomStore from './useChatRoomStore';
 import useLoginUserStore from './useLoginUserStore';
 
 const useSockJS = (chatRoomId: number) => {
+  const { accessToken } = useAccessToken();
   const [{ userType, profile }] = useLoginUserStore();
 
   const [, store] = useChatRoomStore();
@@ -25,12 +27,17 @@ const useSockJS = (chatRoomId: number) => {
           const newMessage = JSON.parse(response.body);
           store.addMessage(newMessage);
         },
-        {},
+        {
+          id: `${chatRoomId}`,
+          Authorization: `Bearer ${accessToken}`,
+        },
       );
     });
 
     return (() => {
-      client.current?.disconnect();
+      client.current?.disconnect(undefined, {
+        id: `${chatRoomId}`,
+      });
     });
   }, []);
 


### PR DESCRIPTION
- 서버측에서 채팅방에 양측 모두 접속해있을 경우 채팅 읽음 처리를 위한 로직 추가 -> 클라이언트 측에서 해당 로직에 필요한 채팅방 번호와 토큰 전달